### PR TITLE
not so great pdf page sequence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>edu.tamu</groupId>
   <artifactId>ir-iiif-service</artifactId>
-  <version>0.5.3</version>
+  <version>0.5.4</version>
   <packaging>war</packaging>
 
   <name>IR IIIF Service</name>

--- a/src/main/java/edu/tamu/iiif/service/dspace/rdf/DSpaceRdfCanvasManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/dspace/rdf/DSpaceRdfCanvasManifestService.java
@@ -19,8 +19,11 @@ public class DSpaceRdfCanvasManifestService extends AbstractDSpaceRdfManifestSer
         String context = request.getContext();
         String handle = extractHandle(context);
         RdfResource rdfResource = getRdfResourceByContextPath(handle);
-        String url = rdfResource.getResource().getURI();
-        Canvas canvas = generateCanvas(request, new RdfResource(rdfResource, url.replace("rdf/handle", config.getWebapp() != null && config.getWebapp().length() > 0 ? config.getWebapp() + "/bitstream" : "bitstream").replaceAll(handle, context)));
+        String uri = rdfResource.getResource().getURI()
+            .replace("rdf/handle", config.getWebapp() != null && config.getWebapp().length() > 0 ? config.getWebapp() + "/bitstream" : "bitstream")
+            .replaceAll(handle, context);
+
+        Canvas canvas = generateCanvas(request, new RdfResource(rdfResource, uri));
         return mapper.writeValueAsString(canvas);
     }
 

--- a/src/main/java/edu/tamu/iiif/service/dspace/rdf/DSpaceRdfCanvasManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/dspace/rdf/DSpaceRdfCanvasManifestService.java
@@ -23,7 +23,7 @@ public class DSpaceRdfCanvasManifestService extends AbstractDSpaceRdfManifestSer
             .replace("rdf/handle", config.getWebapp() != null && config.getWebapp().length() > 0 ? config.getWebapp() + "/bitstream" : "bitstream")
             .replaceAll(handle, context);
 
-        Canvas canvas = generateCanvas(request, new RdfResource(rdfResource, uri));
+        Canvas canvas = generateCanvas(request, new RdfResource(rdfResource, uri), 0);
         return mapper.writeValueAsString(canvas);
     }
 

--- a/src/main/java/edu/tamu/iiif/service/dspace/rdf/DSpaceRdfImageManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/dspace/rdf/DSpaceRdfImageManifestService.java
@@ -18,7 +18,7 @@ public class DSpaceRdfImageManifestService extends AbstractDSpaceRdfManifestServ
     public String generateManifest(ManifestRequest request) throws IOException, URISyntaxException {
         String context = request.getContext();
         String dspacePath = config.getWebapp() != null && config.getWebapp().length() > 0 ? joinPath(config.getUrl(), config.getWebapp(), "bitstream", context) : joinPath(config.getUrl(), "bitstream", context);
-        URI uri = getImageUri(dspacePath);
+        URI uri = getImageUri(dspacePath, 0);
         return fetchImageInfo(uri.toString());
     }
 

--- a/src/main/java/edu/tamu/iiif/service/fedora/pcdm/AbstractFedoraPcdmManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/fedora/pcdm/AbstractFedoraPcdmManifestService.java
@@ -70,11 +70,11 @@ public abstract class AbstractFedoraPcdmManifestService extends AbstractManifest
         return sequence;
     }
 
-    protected Canvas generateCanvas(ManifestRequest request, RdfResource rdfResource) throws IOException, URISyntaxException {
+    protected Canvas generateCanvas(ManifestRequest request, RdfResource rdfResource, int page) throws IOException, URISyntaxException {
         String parameterizedId = RdfModelUtility.getParameterizedId(rdfResource.getResource().getURI(), request);
         PropertyValueSimpleImpl label = getLabel(rdfResource);
 
-        RdfCanvas rdfCanvas = getFedoraRdfCanvas(request, rdfResource);
+        RdfCanvas rdfCanvas = getFedoraRdfCanvas(request, rdfResource, page);
 
         Canvas canvas = new CanvasImpl(getFedoraIiifCanvasUri(parameterizedId), label, rdfCanvas.getHeight(), rdfCanvas.getWidth());
 
@@ -212,7 +212,7 @@ public abstract class AbstractFedoraPcdmManifestService extends AbstractManifest
                 RdfResource fileRdfResource = new RdfResource(fileModel, node.toString());
 
                 if (fileRdfResource.getResourceById(PCDM_HAS_FILE_PREDICATE) != null) {
-                    Canvas canvas = generateCanvas(request, fileRdfResource);
+                    Canvas canvas = generateCanvas(request, fileRdfResource, 0);
                     if (canvas.getImages().size() > 0) {
                         canvases.add(canvas);
                     }
@@ -221,7 +221,7 @@ public abstract class AbstractFedoraPcdmManifestService extends AbstractManifest
         }
 
         if (canvases.isEmpty() && rdfResource.getResourceById(PCDM_HAS_FILE_PREDICATE) != null) {
-            Canvas canvas = generateCanvas(request, rdfResource);
+            Canvas canvas = generateCanvas(request, rdfResource, 0);
             if (canvas.getImages().size() > 0) {
                 canvases.add(canvas);
             }
@@ -244,7 +244,7 @@ public abstract class AbstractFedoraPcdmManifestService extends AbstractManifest
 
             Model orderedModel = getFedoraRdfModel(id.get());
 
-            Canvas canvas = generateCanvas(request, new RdfResource(orderedModel, id.get()));
+            Canvas canvas = generateCanvas(request, new RdfResource(orderedModel, id.get()), 0);
             if (canvas.getImages().size() > 0) {
                 canvases.add(canvas);
             }
@@ -261,7 +261,7 @@ public abstract class AbstractFedoraPcdmManifestService extends AbstractManifest
 
     }
 
-    private RdfCanvas getFedoraRdfCanvas(ManifestRequest request, RdfResource rdfResource) throws URISyntaxException, JsonProcessingException, MalformedURLException, IOException {
+    private RdfCanvas getFedoraRdfCanvas(ManifestRequest request, RdfResource rdfResource, int page) throws URISyntaxException, JsonProcessingException, MalformedURLException, IOException {
         RdfCanvas rdfCanvas = new RdfCanvas();
 
         String parameterizedCanvasId = RdfModelUtility.getParameterizedId(rdfResource.getResource().getURI(), request);
@@ -284,7 +284,7 @@ public abstract class AbstractFedoraPcdmManifestService extends AbstractManifest
                 RdfResource fileRdfResource = new RdfResource(fileModel, node.toString());
 
                 if (fileRdfResource.containsStatement(RDF_TYPE_PREDICATE, PCDM_FILE)) {
-                    Optional<Image> image = generateImage(request, fileRdfResource, parameterizedCanvasId);
+                    Optional<Image> image = generateImage(request, fileRdfResource, parameterizedCanvasId, page);
                     if (image.isPresent()) {
                         rdfCanvas.addImage(image.get());
 

--- a/src/main/java/edu/tamu/iiif/service/fedora/pcdm/FedoraPcdmCanvasManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/fedora/pcdm/FedoraPcdmCanvasManifestService.java
@@ -18,7 +18,7 @@ public class FedoraPcdmCanvasManifestService extends AbstractFedoraPcdmManifestS
     public String generateManifest(ManifestRequest request) throws IOException, URISyntaxException {
         String context = request.getContext();
         RdfResource rdfResource = getRdfResourceByContextPath(context);
-        Canvas canvas = generateCanvas(request, rdfResource);
+        Canvas canvas = generateCanvas(request, rdfResource, 0);
         return mapper.writeValueAsString(canvas);
     }
 

--- a/src/main/java/edu/tamu/iiif/service/fedora/pcdm/FedoraPcdmImageManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/fedora/pcdm/FedoraPcdmImageManifestService.java
@@ -18,7 +18,7 @@ public class FedoraPcdmImageManifestService extends AbstractFedoraPcdmManifestSe
     public String generateManifest(ManifestRequest request) throws IOException, URISyntaxException {
         String context = request.getContext();
         String fedoraPath = joinPath(config.getUrl(), context);
-        URI uri = getImageUri(fedoraPath);
+        URI uri = getImageUri(fedoraPath, 0);
         return fetchImageInfo(uri.toString());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  contextPath:
+  context-path:
   port: 9000
 
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ iiif:
       username: admin
       password: admin
   service:
-    url: http://localhost:${server.port}${server.contextPath}
+    url: http://localhost:${server.port}${server.context-path}
     connection:
       timeout: 1200000
       timeToLive: 1200000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  contextPath:
+  context-path:
   port: 9001
 
 logging:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,7 +30,7 @@ iiif:
     # redis or remote
     type: redis
   service:
-    url: http://localhost:${server.port}${server.contextPath}
+    url: http://localhost:${server.port}${server.context-path}
     connection:
       timeout: 30000
       timeToLive: 30000


### PR DESCRIPTION
Resolves #100 
Resolves #104 

This PR satisfies a current requirement of DSpace PDFs to create a canvas per page. It is not as efficient as it could be due to poorly extensible abstraction design. The file type and info require to be checked while creating the sequence to determine the list of canvases if a pdf. However, the canvas creation already does this for inclusion/exclusion checking. It is not practical to refactor all methods to pass many arguments through to avoid the redundant info requests. If a pdf, there will be a redundant info lookup for each page. I propose a refactor that will also satisfy other issues on the back log as well.