### PR TITLE
[112] Remove devtools.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-devtools</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Devtools now appears to cause problems.
This package is not needed and is merely a developer convenience, so remove it.

resolves #112 