### PR TITLE
Patch cached Redis manifest regression

### DIFF
--- a/src/main/java/edu/tamu/iiif/model/RedisManifest.java
+++ b/src/main/java/edu/tamu/iiif/model/RedisManifest.java
@@ -29,7 +29,7 @@ public class RedisManifest {
 
     private String json;
 
-    private final Long creation;
+    private Long creation;
 
     public RedisManifest() {
         this.creation = new Date().getTime();
@@ -113,6 +113,10 @@ public class RedisManifest {
 
     public Long getCreation() {
         return creation;
+    }
+
+    public void setCreation(Long creation) {
+        this.creation = creation;
     }
 
 }

--- a/src/main/java/edu/tamu/iiif/model/RedisManifest.java
+++ b/src/main/java/edu/tamu/iiif/model/RedisManifest.java
@@ -67,20 +67,40 @@ public class RedisManifest {
         return path;
     }
 
+    public void setPath(String path) {
+        this.path = path;
+    }
+
     public ManifestType getType() {
         return type;
+    }
+
+    public void setType(ManifestType type) {
+        this.type = type;
     }
 
     public String getRepository() {
         return repository;
     }
 
+    public void setRepository(String repository) {
+        this.repository = repository;
+    }
+
     public String getAllowed() {
         return allowed;
     }
 
+    public void setAllowed(String allowed) {
+        this.allowed = allowed;
+    }
+
     public String getDisallowed() {
         return disallowed;
+    }
+
+    public void setDisallowed(String disallowed) {
+        this.disallowed = disallowed;
     }
 
     public String getJson() {


### PR DESCRIPTION
# Description

`RedisManifest` final class member `creation` is no longer supported to be serialized with ` org.springframework.data.mapping.model.InstantiationAwarePropertyAccessor`. Making the property not final and adding a setter resolves the issue.

Fixes #126 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Generated manifest, cached, and fetch cached manifest by making multiple requests to https://api-dev.library.tamu.edu/iiif-service/fedora/collection/london-maps-2


