### PR TITLE
Handle REST client exception for unsupported URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This service provides **IIIF** manifest generation from **DSpace RDF** and/or **
 <details>
 <summary>Example Cantaloupe custom delegate</summary>
 
+```
   require 'base64'
   class CustomDelegate
     ##
@@ -102,6 +103,7 @@ This service provides **IIIF** manifest generation from **DSpace RDF** and/or **
       return uri
     end
   end
+```
 
 </details>
 

--- a/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
@@ -165,10 +165,22 @@ public abstract class AbstractManifestService implements ManifestService {
     }
 
     protected String getRdf(String url) throws NotFoundException {
-        Optional<String> rdf = Optional.ofNullable(restTemplate.getForObject(url, String.class));
-        if (rdf.isPresent()) {
-            logger.debug("RDF for {}: \n{}\n", url, rdf.get());
-            return rdf.get();
+        try {
+            if (logger.isDebugEnabled()) {
+                logger.info("Requesting RDF for {}", url);
+            }
+            Optional<String> rdf = Optional.ofNullable(restTemplate.getForObject(url, String.class));
+            if (rdf.isPresent()) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("RDF for {}: \n{}\n", url, rdf.get());
+                }
+                return rdf.get();
+            }
+        } catch (RestClientException e) {
+            logger.error("Failed to get RDF for {}", url, e);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Error while requesting RDF for {}: {}", url, e.getMessage(), e);
+            }
         }
         throw new NotFoundException("RDF not found! " + url);
     }

--- a/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
@@ -164,23 +164,19 @@ public abstract class AbstractManifestService implements ManifestService {
         return createRdfModel(getRdf(url));
     }
 
-    protected String getRdf(String url) throws NotFoundException {
+    private String getRdf(String url) throws NotFoundException {
         try {
             if (logger.isDebugEnabled()) {
                 logger.info("Requesting RDF for {}", url);
             }
             Optional<String> rdf = Optional.ofNullable(restTemplate.getForObject(url, String.class));
             if (rdf.isPresent()) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("RDF for {}: \n{}\n", url, rdf.get());
-                }
+                logger.debug("RDF for {}: \n{}\n", url, rdf.get());
                 return rdf.get();
             }
         } catch (RestClientException e) {
             logger.error("Failed to get RDF for {}: {}", url, e.getMessage());
-            if (logger.isDebugEnabled()) {
-                logger.debug("Error while requesting RDF for {}: {}", url, e.getMessage(), e);
-            }
+            logger.debug("Error while requesting RDF for {}: {}", url, e.getMessage(), e);
         }
         throw new NotFoundException("RDF not found! " + url);
     }

--- a/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
@@ -177,7 +177,7 @@ public abstract class AbstractManifestService implements ManifestService {
                 return rdf.get();
             }
         } catch (RestClientException e) {
-            logger.error("Failed to get RDF for {}", url, e);
+            logger.error("Failed to get RDF for {}: {}", url, e.getMessage());
             if (logger.isDebugEnabled()) {
                 logger.debug("Error while requesting RDF for {}: {}", url, e.getMessage(), e);
             }


### PR DESCRIPTION
Handles org.springframework.web.client.HttpClientErrorException: 404 when fedora metadata for filename contain special characters.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
