### PR TITLE
Implement multipage pdf support for fedora

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>edu.tamu</groupId>
   <artifactId>ir-iiif-service</artifactId>
-  <version>0.6.0-RC2</version>
+  <version>0.6.0-RC3</version>
 
   <name>IR IIIF Service</name>
 

--- a/src/main/java/edu/tamu/iiif/service/dspace/rdf/AbstractDSpaceRdfManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/dspace/rdf/AbstractDSpaceRdfManifestService.java
@@ -22,7 +22,6 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
@@ -30,17 +29,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 
 import de.digitalcollections.iiif.presentation.model.api.v2.Canvas;
-import de.digitalcollections.iiif.presentation.model.api.v2.Image;
 import de.digitalcollections.iiif.presentation.model.api.v2.ImageResource;
-import de.digitalcollections.iiif.presentation.model.api.v2.PropertyValue;
 import de.digitalcollections.iiif.presentation.model.api.v2.Sequence;
-import de.digitalcollections.iiif.presentation.model.api.v2.Service;
 import de.digitalcollections.iiif.presentation.model.impl.v2.CanvasImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ImageImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ImageResourceImpl;
 import de.digitalcollections.iiif.presentation.model.impl.v2.PropertyValueSimpleImpl;
 import de.digitalcollections.iiif.presentation.model.impl.v2.SequenceImpl;
-import de.digitalcollections.iiif.presentation.model.impl.v2.ServiceImpl;
 import edu.tamu.iiif.config.model.AbstractIiifConfig;
 import edu.tamu.iiif.config.model.DSpaceRdfIiifConfig;
 import edu.tamu.iiif.controller.ManifestRequest;
@@ -205,32 +198,6 @@ public abstract class AbstractDSpaceRdfManifestService extends AbstractManifestS
             }
         }
         return canvases;
-    }
-
-    private Canvas getCanvasPage(Canvas canvas, int page) {
-        String id = canvas.getId().toString() + "?page=" + page;
-        PropertyValue label = new PropertyValueSimpleImpl(canvas.getLabel().getFirstValue() + "?page=" + page);
-        Canvas canvasPage = new CanvasImpl(id, label, canvas.getHeight(), canvas.getWidth());
-        canvasPage.setImages(canvas.getImages().stream().map(i -> {
-            Image image = new ImageImpl(i.getId().toString().replace("/info.json", ";" + page + "/info.json"));
-            ImageResource ir = i.getResource();
-            ImageResource imageResource = new ImageResourceImpl(ir.getId().toString().replace("/full/full/0/default.jpg", ";" + page + "/full/full/0/default.jpg"));
-            imageResource.setFormat(ir.getFormat());
-            imageResource.setHeight(ir.getHeight());
-            imageResource.setWidth(ir.getWidth());
-            List<Service> services = ir.getServices().stream().map(s -> {
-                Service service = new ServiceImpl(s.getId().toString() + ";" + page);
-                service.setLabel(s.getLabel());
-                service.setContext(s.getContext());
-                service.setProfile(s.getProfile());
-                return service;
-            }).collect(Collectors.toList());
-            imageResource.setServices(services);
-            image.setResource(imageResource);
-            image.setOn(i.getOn());
-            return image;
-        }).collect(Collectors.toList()));
-        return canvasPage;
     }
 
     private RdfCanvas getDSpaceRdfCanvas(ManifestRequest request, RdfResource rdfResource, int page) throws URISyntaxException, URISyntaxException {

--- a/src/main/java/edu/tamu/iiif/service/fedora/pcdm/FedoraPcdmCanvasManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/fedora/pcdm/FedoraPcdmCanvasManifestService.java
@@ -7,8 +7,8 @@ import java.net.URISyntaxException;
 
 import org.springframework.stereotype.Service;
 
-import de.digitalcollections.iiif.presentation.model.api.v2.Canvas;
 import edu.tamu.iiif.controller.ManifestRequest;
+import edu.tamu.iiif.model.CanvasWithInfo;
 import edu.tamu.iiif.model.ManifestType;
 import edu.tamu.iiif.model.rdf.RdfResource;
 
@@ -18,8 +18,8 @@ public class FedoraPcdmCanvasManifestService extends AbstractFedoraPcdmManifestS
     public String generateManifest(ManifestRequest request) throws IOException, URISyntaxException {
         String context = request.getContext();
         RdfResource rdfResource = getRdfResourceByContextPath(context);
-        Canvas canvas = generateCanvas(request, rdfResource, 0);
-        return mapper.writeValueAsString(canvas);
+        CanvasWithInfo canvasWithInfo = generateCanvas(request, rdfResource, 0);
+        return mapper.writeValueAsString(canvasWithInfo.getCanvas());
     }
 
     @Override


### PR DESCRIPTION
# Description

Add Fedora support for multipage PDF presentation manifests.

Resolves #137 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Start Redis docker container:

```
docker run -p 6379:6379 redis:4.0.14-alpine
```

Configure service for Cantaloupe and Fedora:

```
iiif.image.server.url: https://api.library.tamu.edu/iiif/2
iiif.fedora.url: https://api.library.tamu.edu/fcrepo/rest
```

Start service:

```
mvn clean spring-boot:run
```

Generate presentation manifest at the page container with pdf resource:

http://localhost:9000/fedora/presentation/3b/6f/c3/25/3b6fc325-f6ca-41d8-b91e-8c5db3be8c13/basbanes-texts_objects/2/pages/page_0

Should expect `application/json` response of presentation manifest with a sequence of 200 canvases, one for each page of the pdf.

![image](https://github.com/TAMULib/IRIIIFService/assets/144841721/97ba2552-fc00-4a02-a3e3-89a54797504a)


Can also be tested in Mirador:

https://library.tamu.edu/mirador/?manifest=http://localhost:9000/fedora/presentation/3b/6f/c3/25/3b6fc325-f6ca-41d8-b91e-8c5db3be8c13/basbanes-texts_objects/2/pages/page_0

![image](https://github.com/TAMULib/IRIIIFService/assets/144841721/0eff89b0-3dd1-4e41-80f4-0ef7094d8cbb)


**Test Configuration**:
* Toolchain: Maven
* SDK: Java 11

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

