### PR TITLE
Partially revert "Issue 150: Fix discovered problems and update unit tests.".

### DIFF
--- a/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
+++ b/src/main/java/edu/tamu/iiif/service/AbstractManifestService.java
@@ -477,13 +477,12 @@ public abstract class AbstractManifestService implements ManifestService {
     }
 
     protected Optional<String> getMimeType(String url) {
-        HttpHeaders headers = restTemplate.headForHeaders(url);
-
-        if (headers == null) {
+        try {
+            HttpHeaders headers = restTemplate.headForHeaders(url);
+            return Optional.ofNullable(headers.getFirst(HttpHeaders.CONTENT_TYPE));
+        } catch (RestClientException e) {
             return Optional.empty();
         }
-
-        return Optional.ofNullable(headers.getFirst(HttpHeaders.CONTENT_TYPE));
     }
 
     private Metadata buildMetadata(String label, String value) {


### PR DESCRIPTION
relates to #150 

This reverts parts of the commit from 822cb2183cafec400903c72d2a440e5d614648d6 involving the mimetype.

Strange problems showed up that are unexpected and did not show up when this branch was deployed and tested.
```
Failed to determine the content type: (URI=https://api-dev.library.tamu.edu/fcrepo/rest/0a/eb/00/7d/0aeb007d-68bc-4c31-bece-508112e6f9c7/q-and-kevin-saf_objects/3/pages/page_0/files/new%20image%20again.jpg : stream=image/jpeg)
```

Investigation shows that these problems already existed but the failure was obscured more.
This reverts puts back some of the original Mimetype code (identified during this WIP commit 822cb2183cafec400903c72d2a440e5d614648d6).
A new issue will need to be created or an existing issue will need to be updated.

The behavior on production looks like this:
```
[line: 1, col: 1 ] Out of place: [KEYWORD:����]
```
See (https://api.library.tamu.edu/iiif-service/fedora/presentation/a6/f0/55/01/a6f05501-9312-4fd5-a167-f7ce2fa28ca6/com_class_rosters_objects/10/pages/page_0/files/COMClass1989.jpg)

The error message on development is improved and looks like:
```
Failed to determine the content type: (URI=https://api-dev.library.tamu.edu/fcrepo/rest/a6/f0/55/01/a6f05501-9312-4fd5-a167-f7ce2fa28ca6/com_class_rosters_objects/10/pages/page_0/files/COMClass1989.jpg : stream=image/jpeg)
```